### PR TITLE
added ms sql pdo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The DORM 0.0.4
+# The DORM 0.0.5
 A lightweight PHP ORM framework with API and no dependencies other than the native PHP extensions. In addition, it has a simple GUI for initializing models based on the tables in the database
 
 ***
@@ -9,7 +9,7 @@ A lightweight PHP ORM framework with API and no dependencies other than the nati
 
 Run Requirements:
 - Minimal PHP Version is PHP 8.0
-- MariaDB 10.5.0
+- MariaDB 10.5.0 or SQL Server 2012 
 
 Implemented functions:
 - PHP model class generator [ Dev ]
@@ -29,6 +29,13 @@ include 'DORM/autoload.php';
 Later the composer option will be added as well.
 
 Next, set in the DORM/Database/config.ini file you database connection data.
+
+For the `db_type` you can use:
+
+| db_type | PDO |
+| ------- | --- |
+| `mysql` |  php\_pdo\_mysql   |
+| `mssql` |  php\_pdo\_sqlsrv\_[php version]\_[ts\|nts]\_[x86\|x64]   |
 
 To call one of the main functions, you must also use ``use`` in one of the three folders.
 

--- a/src/DORM/API/API.php
+++ b/src/DORM/API/API.php
@@ -29,7 +29,7 @@ class API {
 
         if ( isset($request['tables'] ) && is_array($request['tables']) ){
 
-            $dbHandler      = new DBHandler();
+            $dbHandler      = DBHandler::getInstance();
             $modelList      = new ModelList( $dbHandler->getConnection());
             $solvedStack    = [];
 

--- a/src/DORM/Database/DBHandler.php
+++ b/src/DORM/Database/DBHandler.php
@@ -6,6 +6,19 @@ use DORM\Includes\INIWriter;
 
 class DBHandler extends QueryBuilder
 {
+    private static ?DBHandler $instance = null;
+
+    /**
+     * gets the instance via lazy initialization (created on first usage)
+     */
+    public static function getInstance(): DBHandler
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
 
     private $connection = null;
 
@@ -26,57 +39,80 @@ class DBHandler extends QueryBuilder
     {
         $ini = parse_ini_file('config.ini');
 
+        $this->db_type      = $ini['db_type'];
         $this->db_name      = $ini['db_name'];
         $this->db_host      = $ini['db_host'];
         $this->db_user      = $ini['db_user'];
         $this->db_password  = $ini['db_password'];
-        
+
         $this->setDB        = $ini['dorm_db'];
 
         $this->connect();
     }
 
+    /**
+    * executes a function according to the database type with mysql as default
+    */
+    public function dbTypeExecute($mysql = null, $mssql = null)
+    {
+        if (strtolower($this->db_type) == 'mysql' && $mysql) return $mysql();
+        if (strtolower($this->db_type) == 'mssql' && $mssql) return $mssql();
+
+        // default function
+        return $mysql();
+    }
+
     public function connect(): self
     {
         $this->connection = null;
+
         try {
             $this->connection = new \PDO(
-                "mysql:host=$this->db_host; dbname=$this->db_name",
+                $this->dbTypeExecute(
+                    mysql: fn () => "mysql:host=$this->db_host; dbname=$this->db_name",
+                    mssql: fn () => "sqlsrv:server=$this->db_host; Database=$this->db_name",
+                ),
                 $this->db_user,
                 $this->db_password
             );
 
-            $this->connection->exec("set names utf8");
+            $this->dbTypeExecute(
+                mysql: $this->connection->exec("set names utf8"),
+            );
+
             $this->connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->connection->setAttribute(\PDO::ATTR_EMULATE_PREPARES, 1);
 
-            $dbVersion = $this->connection->query('select version()')->fetchColumn();
-            if (strpos( $dbVersion , "MariaDB" ) ) {
-                $this->isMariaDB = true;
+            // $dbVersion = $this->connection->query('select version()')->fetchColumn();
+            // if (strpos( $dbVersion , "MariaDB" ) ) {
+            //     $this->isMariaDB = true;
 
-                // defined('DORM_CONSTANTS') or define('DORM_CONSTANTS', array() );
+            //     // defined('DORM_CONSTANTS') or define('DORM_CONSTANTS', array() );
 
-                // $val =  DORM_CONSTANTS[0];
-                // define("IS_MARIADB", true);
-                // preg_match("/^[0-9\.]+/", $dbVersion, $match);
-                // define("DB_VERSION", $match[0] );
-            };
-
-
+            //     // $val =  DORM_CONSTANTS[0];
+            //     // define("IS_MARIADB", true);
+            //     // preg_match("/^[0-9\.]+/", $dbVersion, $match);
+            //     // define("DB_VERSION", $match[0] );
+            // };
         } catch (\PDOException  $exception) {
             $this->error = "No connection to Database: " . $exception->getMessage();
         }
         return $this;
     }
 
-    public function getTables(){
-        $sql = 'SHOW TABLES';
+    public function getTables()
+    {
+        $sql = $this->dbTypeExecute(
+            mysql: fn () => 'SHOW TABLES',
+            mssql: fn () => "SELECT * FROM SYSOBJECTS WHERE xtype = 'U';",
+        );
 
         $query = $this->connection->query($sql);
         return $query->fetchAll(\PDO::FETCH_COLUMN);
     }
 
-    public function getColumns($tableName){
+    public function getColumns($tableName)
+    {
         $sql = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{$tableName}'";
 
         $query = $this->connection->query($sql);
@@ -85,70 +121,104 @@ class DBHandler extends QueryBuilder
 
     public function getTableReferences($tableName)
     {
-        $sql = "
+        // TODO: replace REFERENCED_TABLE_SCHEMA
+
+        $sql = $this->dbTypeExecute(
+            mysql: fn () =>  "
             SELECT  TABLE_NAME,
                     COLUMN_NAME,
                     REFERENCED_TABLE_NAME,
                     REFERENCED_COLUMN_NAME 
             FROM information_schema.KEY_COLUMN_USAGE
             WHERE REFERENCED_TABLE_SCHEMA = 'kada0005_db4'
-			    AND TABLE_NAME = '{$tableName}'
-        ";
+        	    AND TABLE_NAME = '{$tableName}'
+        ",
+            mssql: fn () => "
+            SELECT  Tab.TABLE_NAME, Col.TABLE_NAME as REFERENCED_TABLE_NAME, Col.COLUMN_NAME as COLUMN_NAME, Col.COLUMN_NAME as REFERENCED_COLUMN_NAME
+            FROM
+            INFORMATION_SCHEMA.TABLE_CONSTRAINTS Tab, 
+            INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE Col 
+                WHERE Tab.CONSTRAINT_CATALOG = 'dud' AND Tab.TABLE_NAME = '{$tableName}'
+            ",
+        );
 
-        return $this->execute( $sql );
+        return $this->execute($sql);
     }
 
 
-    public function isDormDB():bool {
-        if($this->setDB == 'true') return true;
+    public function isDormDB(): bool
+    {
+        if ($this->setDB == 'true') return true;
 
         return false;
     }
 
-    public function setDormDB(){
+    public function setDormDB()
+    {
 
         $exist = $this->execute("SELECT * FROM INFORMATION_SCHEMA.TABLES
            WHERE TABLE_NAME = 'dorm_model_list' ");
 
-        if(  count($exist->fetchAll(\PDO::FETCH_ASSOC)) <= 0 ) $this->setDatabase();
+        if (count($exist->fetchAll(\PDO::FETCH_ASSOC)) <= 0) $this->setDatabase();
 
         $ini = parse_ini_file('config.ini');
         $ini['dorm_db'] = "true";
 
-        $ini = (new INIWriter())->writeValue(  $ini , __DIR__ . '/config.ini' );
-
+        $ini = (new INIWriter())->writeValue($ini, __DIR__ . '/config.ini');
     }
 
     public function setDatabase()
     {
+        $sql = $this->dbTypeExecute(
+            mysql: fn () => "
+                CREATE TABLE IF NOT EXISTS dorm_model_list (
+                    table_name varchar(100) NOT NULL,
+                    class_name varchar(100) NOT NULL,
+                    create_timestamp timestamp NOT NULL,
+
+                    PRIMARY KEY(table_name)
+                );
+            ",
+            mssql: fn () => "
+                    IF  NOT EXISTS (SELECT * FROM sys.objects 
+                    WHERE object_id = OBJECT_ID(N'[dbo].[dorm_model_list]') AND type in (N'U'))
+                    
+                    BEGIN
+                    CREATE TABLE dorm_model_list (
+                        table_name varchar(100) NOT NULL,
+                        class_name varchar(100) NOT NULL,
+                        create_timestamp timestamp NOT NULL,
+                    
+                        PRIMARY KEY(table_name)
+                    );
+                    END
+            ",
+        );
+
+        $this->connection->exec($sql);
+    }
+    public function insertModel(string $tableName, string $className)
+    {
         $sql = "
-            CREATE TABLE IF NOT EXISTS dorm_model_list (
-                table_name varchar(100) NOT NULL,
-                class_name varchar(100) NOT NULL,
-                create_timestamp timestamp NOT NULL,
-
-                PRIMARY KEY(table_name)
-            );
-        ";
-
-        $this->connection->exec($sql);
-    }
-    public function insertModel( string $tableName, string $className){
-        $sql = "REPLACE INTO dorm_model_list ( table_name, class_name)
-                VALUES ( '{$tableName}', '{$className}' )";
+        BEGIN TRANSACTION;
+        DELETE FROM dorm_model_list WHERE table_name = '{$tableName}';
+        INSERT INTO dorm_model_list (table_name, class_name) VALUES ('{$tableName}', '{$className}');
+        COMMIT;";
 
         $this->connection->exec($sql);
     }
 
-    public function getConnection(){
+    public function getConnection()
+    {
         return $this->connection;
     }
 
-    public function execute(string $sqlQuery) {
-            $query = $this->connection->prepare($sqlQuery);
-            $query->execute();
+    public function execute(string $sqlQuery)
+    {
+        $query = $this->connection->prepare($sqlQuery);
+        $query->execute();
 
-            return $query;
-            // return $query->fetchAll(\PDO::FETCH_ASSOC);
+        return $query;
+        // return $query->fetchAll(\PDO::FETCH_ASSOC);
     }
 }

--- a/src/DORM/Database/SQLClasses/Select.php
+++ b/src/DORM/Database/SQLClasses/Select.php
@@ -1,38 +1,45 @@
 <?php
+
 namespace DORM\Database\SQLClasses;
 
-class Select {
+use DORM\Database\DBHandler;
+
+class Select
+{
 
     private $columns = [];
 
     private $from = [];
 
     private $where = null;
-    
+
     private $leftJoin = [];
 
     private $limit = 1000;
-    
-    public function __construct( array $columns = null ){
-        ($columns != null ) ? $this->columns = $columns : $this->columns = array( '*' );
+
+    public function __construct(array $columns = null)
+    {
+        ($columns != null) ? $this->columns = $columns : $this->columns = array('*');
     }
 
-    public function from ( string $table, string $alias = null): self {
-
+    public function from(string $table, string $alias = null): self
+    {
         $this->from[] = $alias === null ? $table : "${table} AS ${alias}";
         return $this;
     }
 
     // ToDo: Where als eigene Klasse auslagern? wird auch in select gebraucht etc.
-    public function where( string $column, string $condition, string $value ): self {
+    public function where(string $column, string $condition, string $value): self
+    {
 
-        $this->where = $column . " " . $condition . " " . $value;
+        $this->where = $column . " " . $condition . " '" . $value . "'";
         return $this;
     }
 
     // ToDo: reduce to one pair if same ?
-    public function join( string $table1, string $table2, string $column1, string $column2 = null ): self {
-        
+    public function join(string $table1, string $table2, string $column1, string $column2 = null): self
+    {
+
         $sql = "%TABLE2% ON %TABLE1%.%COLUMN1% = %TABLE2%.%COLUMN2%";
 
         $sql = str_replace("%TABLE1%", $table1, $sql);
@@ -45,21 +52,24 @@ class Select {
         return $this;
     }
 
-    public function limit( int $limit ): self {
+    public function limit(int $limit): self
+    {
         $this->limit = $limit;
         return $this;
     }
 
-    public function __toString(): string {
-
-        return 'SELECT ' . implode( ', ', $this->columns )
-            . ' FROM ' . implode( ', ', $this->from )
-            . ($this->leftJoin === [] ? '' : ' LEFT JOIN ' . implode(' LEFT JOIN ', $this->leftJoin))
-            . ($this->where === null  ?  " " : " WHERE " . $this->where)
-            . " LIMIT " . $this->limit;
+    public function __toString(): string
+    {
+        return DBHandler::getInstance()->dbTypeExecute(
+            mysql: fn () => 'SELECT ' . implode(', ', $this->columns)
+                . ' FROM ' . implode(', ', $this->from)
+                . ($this->leftJoin === [] ? '' : ' LEFT JOIN ' . implode(' LEFT JOIN ', $this->leftJoin))
+                . ($this->where === null  ?  " " : " WHERE " . $this->where)
+                . " LIMIT " . $this->limit,
+            mssql: fn () => 'SELECT ' . " TOP " . $this->limit .  " " . implode(', ', $this->columns)
+                . ' FROM ' . implode(', ', $this->from)
+                . ($this->leftJoin === [] ? '' : ' LEFT JOIN ' . implode(' LEFT JOIN ', $this->leftJoin))
+                . ($this->where === null  ?  " " : " WHERE " . $this->where)
+        );
     }
-
 }
-
-
-?>

--- a/src/DORM/Database/SQLClasses/Update.php
+++ b/src/DORM/Database/SQLClasses/Update.php
@@ -24,11 +24,9 @@ class Update {
 
     // ToDo: Where als eigene Klasse auslagern? wird auch in select gebraucht etc.
     public function where( string $column, string $condition, string $value ): self {
-        $this->where = $column . " " . $condition . " " . $value;
+        $this->where = $column . " " . $condition . "'" . $value . "'";
         return $this; 
     }
-
-
 
     public function __toString(){
         

--- a/src/DORM/Database/sample.config.ini
+++ b/src/DORM/Database/sample.config.ini
@@ -1,4 +1,5 @@
 [database]
+db_type     = 
 db_name     = 
 db_host     = 
 db_user     = 

--- a/src/DORM/Includes/Setup.php
+++ b/src/DORM/Includes/Setup.php
@@ -10,7 +10,7 @@ class Setup
 
     function __construct()
     {
-        $this->connection = new DBHandler();
+        $this->connection = DBHandler::getInstance();
         $this->render();
     }
 

--- a/src/setup.php
+++ b/src/setup.php
@@ -6,6 +6,6 @@ include 'DORM/autoload.php';
 
 new Setup();
 
-$conn = new DBHandler();
+$conn = DBHandler::getInstance();
 
 ?>


### PR DESCRIPTION
- added db_type property to the config.ini
- made DBHandler to a singleton
- added dbTypeExecute function in DBHandler to execute different function according to the database type
- added functions needed for Microsoft SQl connections
- changed README to new version 0.0.5 for the DORM and added the db_type in the setup section
- Added single quotes for strings in where clauses

The DBHandler was changed to a singleton to access the dbTypeExecute  function globally. In my case in the __toString() method of the Select class.